### PR TITLE
chore: bump outdated starknet related versions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,8 +22,9 @@ thiserror = "1.0" # Error handling
 async-trait = "0.1.74" # Async traits
 hex = "0.4.3" # Hex encoding
 tiny-keccak = "2.0.2" # Keccak hashing
-starknet = "0.6.0" # StarkNet pedersen
-starknet-crypto = "0.6.0" # StarkNet poseidon
+starknet = "0.11.0"
+starknet-crypto = "0.7.1"
+starknet-types-core = "0.1.5"
 uuid = { version = "1.4.1", features = ["v4"] } # UUID
 parking_lot = "0.12.1" # Sync mutex
 num-bigint = "0.4.4" # Bigints in hashers (TODO: double check if needed)

--- a/src/hasher/core.rs
+++ b/src/hasher/core.rs
@@ -1,4 +1,4 @@
-use starknet::core::types::FromStrError;
+use starknet_types_core::felt::FromStrError;
 use std::{fmt::Debug, str::FromStr};
 use strum_macros::EnumIter;
 use thiserror::Error;

--- a/src/hasher/hashers/stark_pedersen.rs
+++ b/src/hasher/hashers/stark_pedersen.rs
@@ -1,4 +1,5 @@
-use starknet::core::{crypto::pedersen_hash, types::FieldElement};
+use starknet::core::crypto::pedersen_hash;
+use starknet_crypto::Felt;
 
 use crate::hasher::{byte_size, HasherError, HashingFunction};
 
@@ -69,11 +70,8 @@ impl StarkPedersenHasher {
             self.is_element_size_valid(element)?;
         }
 
-        let result = pedersen_hash(
-            &FieldElement::from_hex_be(&data[0])?,
-            &FieldElement::from_hex_be(&data[1])?,
-        )
-        .to_bytes_be();
+        let result =
+            pedersen_hash(&Felt::from_hex(&data[0])?, &Felt::from_hex(&data[1])?).to_bytes_be();
 
         let padded_hex_str = format!("0x{:0>64}", hex::encode(result));
         Ok(padded_hex_str)

--- a/src/hasher/hashers/stark_poseidon.rs
+++ b/src/hasher/hashers/stark_poseidon.rs
@@ -1,8 +1,7 @@
 use crate::hasher::{byte_size, HasherError, HashingFunction};
 
 use super::super::Hasher;
-use starknet::core::types::FieldElement;
-use starknet_crypto::{poseidon_hash, poseidon_hash_many, poseidon_hash_single};
+use starknet_crypto::{poseidon_hash, poseidon_hash_many, poseidon_hash_single, Felt};
 
 /// Hasher for Stark Poseidon
 #[derive(Debug, Clone)]
@@ -26,7 +25,7 @@ impl Hasher for StarkPoseidonHasher {
             self.is_element_size_valid(element)?;
         }
 
-        let field_elements: Vec<FieldElement> =
+        let field_elements: Vec<Felt> =
             data.iter().map(|e| e.parse().unwrap_or_default()).collect();
 
         let hash_core = match field_elements.len() {


### PR DESCRIPTION
```
starknet = "0.11.0"
starknet-crypto = "0.7.1"
starknet-types-core = "0.1.5"
```