### PR TITLE
Optimized SQLite and MMR implementations

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ exclude = [".github", ".vscode"]
 
 [dependencies]
 tokio = { version = "1.33.0", features = ["full"] } # Async runtime
-sqlx = { version = "0.7", features = [
+sqlx = { version = "0.8", features = [
     "runtime-tokio",
     "sqlite",
 ] } # SQLite for rust

--- a/src/mmr/core.rs
+++ b/src/mmr/core.rs
@@ -6,6 +6,7 @@ use uuid::Uuid;
 
 use crate::hasher::{Hasher, HasherError, HashingFunction};
 use crate::store::{InStoreCounter, InStoreTable, InStoreTableError, Store, StoreError, SubKey};
+use crate::mmr::helpers::leaf_count_to_mmr_size;
 
 use crate::mmr::{
     formatting::{format_peaks, format_proof, PeaksFormattingOptions},
@@ -220,45 +221,46 @@ impl MMR {
         })
     }
 
+
+
     pub async fn rewind(&mut self, leaf_index: usize) -> Result<Vec<String>, MMRError> {
+        // 1) check leaf_index is not out-of-bounds
         let cur_leaf_count = self.leaves_count.get().await?;
-        if leaf_index > cur_leaf_count {
+        if leaf_index >= cur_leaf_count {
             return Err(MMRError::InvalidElementIndex);
         }
 
-        // all leaf indices after the passed leaf index
-        let pruned_leaf_indices: Vec<usize> = ((leaf_index + 1)..cur_leaf_count)
-            .map(|leaf_index| {
-                let element_index = map_leaf_index_to_element_index(leaf_index);
-                element_index
-            })
+        // 2) figure out the MMR size if we want to keep (leaf_index + 1) leaves
+        let new_leaf_count = leaf_index + 1;
+        let new_elements_count = leaf_count_to_mmr_size(new_leaf_count);
+
+        // 3) gather all leaf indexes from [new_leaf_count..cur_leaf_count) 
+        //    (these are the ones we are about to drop)
+        let pruned_leaf_indices: Vec<usize> = (new_leaf_count..cur_leaf_count)
+            .map(|leaf_idx| map_leaf_index_to_element_index(leaf_idx))
             .collect();
 
-        // now collect the leaf hashes for each of these
+        // 4) store their hashes so we can return them
         let pruned_leaf_hashes = self
             .hashes
             .get_many(pruned_leaf_indices.into_iter().map(SubKey::Usize).collect())
             .await?;
 
-        let pre_rewind_elements_count = self.elements_count.get().await?;
+        let old_count = self.elements_count.get().await?;
 
-        let element_index = map_leaf_index_to_element_index(leaf_index);
-
-        let post_rewind_elements_count = element_index;
-        let post_rewind_leaves_count = leaf_index + 1;
-
-        self.elements_count.set(post_rewind_elements_count).await?;
-        // truncate hashes past the element index of the passed leaf
+        // 5) actually wipe everything after `new_elements_count`
         self.hashes
-            .delete_range(post_rewind_elements_count + 1, pre_rewind_elements_count)
+            .delete_range(new_elements_count + 1, old_count)
             .await?;
 
-        // recalculate the root hash
-        let bag = self.bag_the_peaks(Some(post_rewind_elements_count)).await?;
-        let root_hash = self.calculate_root_hash(&bag, post_rewind_elements_count)?;
+        // 6) bag + recalc root
+        let bag = self.bag_the_peaks(Some(new_elements_count)).await?;
+        let root_hash = self.calculate_root_hash(&bag, new_elements_count)?;
         self.root_hash.set(&root_hash, SubKey::None).await?;
 
-        self.leaves_count.set(post_rewind_leaves_count).await?;
+        // 7) set the new counters
+        self.elements_count.set(new_elements_count).await?;
+        self.leaves_count.set(new_leaf_count).await?;
 
         Ok(pruned_leaf_hashes.values().cloned().collect())
     }

--- a/src/mmr/core.rs
+++ b/src/mmr/core.rs
@@ -1,4 +1,4 @@
-use std::collections::{HashMap, VecDeque};
+use std::collections::{HashMap, HashSet, VecDeque};
 use std::str::FromStr;
 use std::sync::Arc;
 use thiserror::Error;
@@ -46,6 +46,8 @@ pub enum MMRError {
     InvalidRewindTarget,
     #[error("No hash found for index {0}")]
     NoHashFoundForIndex(usize),
+    #[error("Batch processing failed")]
+    BatchProcessingFailed,
 }
 
 #[derive(Debug)]
@@ -221,7 +223,94 @@ impl MMR {
         })
     }
 
+    pub async fn batch_append(&mut self, values: Vec<String>) -> Result<Vec<AppendResult>, MMRError> {
+        if values.is_empty() {
+            return Ok(Vec::new());
+        }
 
+        for value in &values {
+            self.hasher.is_element_size_valid(value)?;
+        }
+
+        let initial_elements_count = self.elements_count.get().await?;
+        let initial_leaves_count = self.leaves_count.get().await?;
+        
+        let initial_peaks_idxs = find_peaks(initial_elements_count);
+        let mut current_peaks = self.retrieve_peaks_hashes(initial_peaks_idxs, None).await?;
+        
+        let mut results = Vec::with_capacity(values.len());
+        let mut hashes_to_store = HashMap::with_capacity(values.len() * 2);
+        
+        let mut elements_count = initial_elements_count;
+        let mut leaves_count = initial_leaves_count;
+        
+        for value in values {
+            elements_count += 1;
+            let leaf_element_index = elements_count;
+            hashes_to_store.insert(SubKey::Usize(leaf_element_index), value.clone());
+            current_peaks.push(value);
+            let no_merges = leaf_count_to_append_no_merges(leaves_count);
+            
+            for _ in 0..no_merges {
+                elements_count += 1;
+                
+                let right_hash = match current_peaks.pop() {
+                    Some(hash) => hash,
+                    None => return Err(MMRError::NoHashFoundForIndex(elements_count)),
+                };
+                
+                let left_hash = match current_peaks.pop() {
+                    Some(hash) => hash,
+                    None => return Err(MMRError::NoHashFoundForIndex(elements_count)),
+                };
+                
+                let parent_hash = self.hasher.hash(vec![left_hash, right_hash])?;
+                
+                hashes_to_store.insert(SubKey::Usize(elements_count), parent_hash.clone());
+                current_peaks.push(parent_hash);
+            }
+            
+            leaves_count += 1;
+            
+            let bag = self.bag_the_peaks_in_memory(&current_peaks)?;
+            let root_hash = self.calculate_root_hash(&bag, elements_count)?;
+            
+            results.push(AppendResult {
+                leaves_count,
+                elements_count,
+                element_index: leaf_element_index,
+                root_hash: root_hash.clone(),
+            });
+        }
+        
+        self.hashes.set_many(hashes_to_store).await?;
+        self.elements_count.set(elements_count).await?;
+        self.leaves_count.set(leaves_count).await?;
+        
+        if let Some(last_result) = results.last() {
+            self.root_hash.set(&last_result.root_hash, SubKey::None).await?;
+        }
+        
+        Ok(results)
+    }
+
+    pub fn bag_the_peaks_in_memory(&self, peaks_hashes: &[String]) -> Result<String, MMRError> {
+        match peaks_hashes.len() {
+            0 => Ok("0x0".to_string()),
+            1 => Ok(peaks_hashes[0].clone()),
+            _ => {
+                let mut peaks_hashes = VecDeque::from(peaks_hashes.to_vec());
+                let last = peaks_hashes.pop_back().unwrap();
+                let second_last = peaks_hashes.pop_back().unwrap();
+                
+                let root0 = self.hasher.hash(vec![second_last, last])?;
+                
+                Ok(peaks_hashes.into_iter().rev().fold(root0, |prev, cur| {
+                    self.hasher.hash(vec![cur, prev]).unwrap()
+                }))
+            }
+        }
+    }
 
     pub async fn rewind(&mut self, leaf_index: usize) -> Result<Vec<String>, MMRError> {
         // 1) check leaf_index is not out-of-bounds
@@ -230,9 +319,18 @@ impl MMR {
             return Err(MMRError::InvalidElementIndex);
         }
 
+        if leaf_index == cur_leaf_count - 1 {
+            return Ok(Vec::new());
+        }
+
         // 2) figure out the MMR size if we want to keep (leaf_index + 1) leaves
         let new_leaf_count = leaf_index + 1;
         let new_elements_count = leaf_count_to_mmr_size(new_leaf_count);
+        let old_count = self.elements_count.get().await?;
+
+        if new_elements_count == old_count {
+            return Ok(Vec::new());
+        }
 
         // 3) gather all leaf indexes from [new_leaf_count..cur_leaf_count) 
         //    (these are the ones we are about to drop)
@@ -241,17 +339,23 @@ impl MMR {
             .collect();
 
         // 4) store their hashes so we can return them
-        let pruned_leaf_hashes = self
-            .hashes
-            .get_many(pruned_leaf_indices.into_iter().map(SubKey::Usize).collect())
-            .await?;
-
-        let old_count = self.elements_count.get().await?;
-
-        // 5) actually wipe everything after `new_elements_count`
-        self.hashes
-            .delete_range(new_elements_count + 1, old_count)
-            .await?;
+        let pruned_leaf_hashes = if !pruned_leaf_indices.is_empty() {
+            let sub_keys: Vec<SubKey> = pruned_leaf_indices
+                .iter()
+                .map(|&idx| SubKey::Usize(idx))
+                .collect();
+            
+            let hashes_map = self.hashes.get_many(sub_keys).await?;
+            
+            // 5) actually wipe everything after `new_elements_count`
+            self.hashes
+                .delete_range(new_elements_count + 1, old_count)
+                .await?;
+                
+            hashes_map.values().cloned().collect()
+        } else {
+            Vec::new()
+        };
 
         // 6) bag + recalc root
         let bag = self.bag_the_peaks(Some(new_elements_count)).await?;
@@ -262,7 +366,7 @@ impl MMR {
         self.elements_count.set(new_elements_count).await?;
         self.leaves_count.set(new_leaf_count).await?;
 
-        Ok(pruned_leaf_hashes.values().cloned().collect())
+        Ok(pruned_leaf_hashes)
     }
 
     pub async fn get_proof(
@@ -285,40 +389,41 @@ impl MMR {
         }
 
         let peaks = find_peaks(tree_size);
-
         let siblings = find_siblings(element_index, tree_size)?;
 
         let formatting_opts = options
             .formatting_opts
             .as_ref()
             .map(|opts| opts.peaks.clone());
+            
         let peaks_hashes = self.retrieve_peaks_hashes(peaks, formatting_opts).await?;
 
-        let siblings_hashes = self
+        let mut all_indices = siblings.clone();
+        all_indices.push(element_index);
+        
+        let all_hashes = self
             .hashes
             .get_many(
-                siblings
-                    .clone()
+                all_indices
                     .into_iter()
                     .map(SubKey::Usize)
-                    .collect::<Vec<SubKey>>(),
+                    .collect()
             )
             .await?;
-
+            
+        let element_hash = all_hashes
+            .get(&element_index.to_string())
+            .cloned()
+            .ok_or(MMRError::NoHashFoundForIndex(element_index))?;
+            
         let mut siblings_hashes_vec: Vec<String> = siblings
             .iter()
-            .filter_map(|&idx| siblings_hashes.get(&idx.to_string()).cloned())
+            .filter_map(|&idx| all_hashes.get(&idx.to_string()).cloned()) // Note the conversion here
             .collect();
 
         if let Some(formatting_opts) = options.formatting_opts.as_ref() {
             siblings_hashes_vec = format_proof(siblings_hashes_vec, formatting_opts.proof.clone())?;
         }
-
-        let element_hash = self
-            .hashes
-            .get(SubKey::Usize(element_index))
-            .await?
-            .ok_or(MMRError::NoHashFoundForIndex(element_index))?;
 
         Ok(Proof {
             element_index,
@@ -334,6 +439,10 @@ impl MMR {
         elements_indexes: Vec<usize>,
         options: Option<ProofOptions>,
     ) -> Result<Vec<Proof>, MMRError> {
+        if elements_indexes.is_empty() {
+            return Ok(Vec::new());
+        }
+        
         let options = options.unwrap_or_default();
         let tree_size = match options.elements_count {
             Some(count) => count,
@@ -341,10 +450,7 @@ impl MMR {
         };
 
         for &element_index in &elements_indexes {
-            if element_index == 0 {
-                return Err(MMRError::InvalidElementIndex);
-            }
-            if element_index > tree_size {
+            if element_index == 0 || element_index > tree_size {
                 return Err(MMRError::InvalidElementIndex);
             }
         }
@@ -352,40 +458,49 @@ impl MMR {
         let peaks = find_peaks(tree_size);
         let peaks_hashes = self.retrieve_peaks_hashes(peaks, None).await?;
 
+        let mut all_indices = HashSet::new();
         let mut siblings_per_element = HashMap::new();
+        
         for &element_id in &elements_indexes {
-            siblings_per_element.insert(element_id, find_siblings(element_id, tree_size)?);
+            let siblings = find_siblings(element_id, tree_size)?;
+            siblings_per_element.insert(element_id, siblings.clone());
+            
+            all_indices.insert(element_id);
+            for &sibling in &siblings {
+                all_indices.insert(sibling);
+            }
         }
-        let sibling_hashes_to_get = array_deduplicate(
-            siblings_per_element
-                .values()
-                .flat_map(|x| x.iter().cloned())
-                .collect(),
-        )
-        .into_iter()
-        .map(SubKey::Usize)
-        .collect();
-        let all_siblings_hashes = self.hashes.get_many(sibling_hashes_to_get).await?;
 
-        let elements_ids_str: Vec<SubKey> =
-            elements_indexes.iter().map(|&x| SubKey::Usize(x)).collect();
-        let element_hashes = self.hashes.get_many(elements_ids_str).await?;
+        let all_hash_keys: Vec<SubKey> = all_indices
+            .iter()
+            .copied()
+            .map(SubKey::Usize)
+            .collect();
+            
+        let all_hashes = self.hashes.get_many(all_hash_keys).await?;
 
-        let mut proofs: Vec<Proof> = Vec::new();
+        let mut proofs = Vec::with_capacity(elements_indexes.len());
+        
         for &element_id in &elements_indexes {
+            let element_hash = all_hashes
+                .get(&element_id.to_string())
+                .cloned()
+                .ok_or(MMRError::NoHashFoundForIndex(element_id))?;
+                
             let siblings = siblings_per_element.get(&element_id).unwrap();
+            
             let mut siblings_hashes: Vec<String> = siblings
                 .iter()
-                .map(|s| all_siblings_hashes.get(&s.to_string()).unwrap().clone()) // Note the conversion here
+                .map(|&s| all_hashes.get(&s.to_string()).unwrap().clone())
                 .collect();
 
             if let Some(formatting_opts) = &options.formatting_opts {
-                siblings_hashes = format_proof(siblings_hashes, formatting_opts.proof.clone())?
+                siblings_hashes = format_proof(siblings_hashes, formatting_opts.proof.clone())?;
             }
 
             proofs.push(Proof {
                 element_index: element_id,
-                element_hash: element_hashes.get(&element_id.to_string()).unwrap().clone(),
+                element_hash,
                 siblings_hashes,
                 peaks_hashes: peaks_hashes.clone(),
                 elements_count: tree_size,
@@ -401,11 +516,20 @@ impl MMR {
         element_value: String,
         options: Option<ProofOptions>,
     ) -> Result<bool, MMRError> {
+        let element_index = proof.element_index;
+        if element_index == 0 {
+            return Err(MMRError::InvalidElementIndex);
+        }
+        
         let options = options.unwrap_or_default();
         let tree_size = match options.elements_count {
             Some(count) => count,
             None => self.elements_count.get().await?,
         };
+
+        if element_index > tree_size {
+            return Err(MMRError::InvalidElementIndex);
+        }
 
         let leaf_count = mmr_size_to_leaf_count(tree_size);
         let peaks_count = leaf_count_to_peaks_count(leaf_count);
@@ -418,32 +542,8 @@ impl MMR {
             let proof_format_null_value = &formatting_opts.proof.null_value;
             let peaks_format_null_value = &formatting_opts.peaks.null_value;
 
-            let proof_null_values_count = proof
-                .siblings_hashes
-                .iter()
-                .filter(|&s| s == proof_format_null_value)
-                .count();
-            proof
-                .siblings_hashes
-                .truncate(proof.siblings_hashes.len() - proof_null_values_count);
-
-            let peaks_null_values_count = proof
-                .peaks_hashes
-                .iter()
-                .filter(|&s| s == peaks_format_null_value)
-                .count();
-            proof
-                .peaks_hashes
-                .truncate(proof.peaks_hashes.len() - peaks_null_values_count);
-        }
-        let element_index = proof.element_index;
-
-        if element_index == 0 {
-            return Err(MMRError::InvalidElementIndex);
-        }
-
-        if element_index > tree_size {
-            return Err(MMRError::InvalidElementIndex);
+            proof.siblings_hashes.retain(|s| s != proof_format_null_value);
+            proof.peaks_hashes.retain(|s| s != peaks_format_null_value);
         }
 
         let (peak_index, peak_height) = get_peak_info(tree_size, element_index);
@@ -451,25 +551,27 @@ impl MMR {
             return Ok(false);
         }
 
-        let mut hash = element_value.clone();
+        let mut hash = element_value;
         let mut leaf_index = element_index_to_leaf_index(element_index)?;
 
-        for proof_hash in proof.siblings_hashes.iter() {
+        for proof_hash in &proof.siblings_hashes {
             let is_right = leaf_index % 2 == 1;
             leaf_index /= 2;
 
-            hash = self.hasher.hash(if is_right {
-                vec![proof_hash.clone(), hash.clone()]
+            hash = if is_right {
+                self.hasher.hash(vec![proof_hash.clone(), hash])?
             } else {
-                vec![hash.clone(), proof_hash.clone()]
-            })?;
+                self.hasher.hash(vec![hash, proof_hash.clone()])?
+            };
         }
 
-        let peak_hashes = self
-            .retrieve_peaks_hashes(find_peaks(tree_size), None)
-            .await?;
+        let peak_hashes = if !proof.peaks_hashes.is_empty() {
+            proof.peaks_hashes
+        } else {
+            self.retrieve_peaks_hashes(find_peaks(tree_size), None).await?
+        };
 
-        Ok(peak_hashes[peak_index] == hash)
+        Ok(peak_index < peak_hashes.len() && peak_hashes[peak_index] == hash)
     }
 
     pub async fn get_peaks(&self, option: PeaksOptions) -> Result<Vec<String>, MMRError> {
@@ -480,11 +582,9 @@ impl MMR {
 
         let peaks_idxs = find_peaks(tree_size);
         let peaks = self.retrieve_peaks_hashes(peaks_idxs, None).await?;
-        if (option.formatting_opts).is_some() {
-            match format_peaks(peaks, &option.formatting_opts.unwrap()) {
-                Ok(peaks) => Ok(peaks),
-                Err(e) => Err(MMRError::Formatting(e)),
-            }
+        
+        if let Some(formatting_opts) = option.formatting_opts {
+            format_peaks(peaks, &formatting_opts).map_err(MMRError::Formatting)
         } else {
             Ok(peaks)
         }
@@ -495,21 +595,20 @@ impl MMR {
         peak_idxs: Vec<usize>,
         formatting_opts: Option<PeaksFormattingOptions>,
     ) -> Result<Vec<String>, MMRError> {
-        let hashes_result = self
-            .hashes
-            .get_many(peak_idxs.clone().into_iter().map(SubKey::Usize).collect())
-            .await?;
+        if peak_idxs.is_empty() {
+            return Ok(Vec::new());
+        }
+        
+        let sub_keys: Vec<SubKey> = peak_idxs.iter().map(|&idx| SubKey::Usize(idx)).collect();
+        let hashes_result = self.hashes.get_many(sub_keys).await?;
         // Assuming hashes_result is a HashMap<String, String>
         let hashes: Vec<String> = peak_idxs
             .iter()
             .filter_map(|&idx| hashes_result.get(&idx.to_string()).cloned())
             .collect();
-
+            
         match formatting_opts {
-            Some(opts) => match format_peaks(hashes, &opts) {
-                Ok(peaks) => Ok(peaks),
-                Err(e) => Err(MMRError::Formatting(e)),
-            },
+            Some(opts) => format_peaks(hashes, &opts).map_err(MMRError::Formatting),
             None => Ok(hashes),
         }
     }
@@ -519,25 +618,20 @@ impl MMR {
             Some(count) => count,
             None => self.elements_count.get().await?,
         };
+        
         let peaks_idxs = find_peaks(tree_size);
-
-        let peaks_hashes = self.retrieve_peaks_hashes(peaks_idxs.clone(), None).await?;
-
-        match peaks_idxs.len() {
-            // Use original peaks_idxs here
-            0 => Ok("0x0".to_string()),
-            1 => Ok(peaks_hashes[0].clone()),
-            _ => {
-                let mut peaks_hashes: VecDeque<String> = peaks_hashes.into();
-                let last = peaks_hashes.pop_back().unwrap();
-                let second_last = peaks_hashes.pop_back().unwrap();
-                let root0 = self.hasher.hash(vec![second_last, last])?;
-
-                Ok(peaks_hashes.into_iter().rev().fold(root0, |prev, cur| {
-                    self.hasher.hash(vec![cur, prev]).unwrap()
-                }))
-            }
+        if peaks_idxs.is_empty() {
+            return Ok("0x0".to_string());
         }
+        
+        if peaks_idxs.len() == 1 {
+            // Use original peaks_idxs here
+            return self.hashes.get(SubKey::Usize(peaks_idxs[0])).await?
+                .ok_or(MMRError::NoHashFoundForIndex(peaks_idxs[0]));
+        }
+
+        let peaks_hashes = self.retrieve_peaks_hashes(peaks_idxs, None).await?;
+        self.bag_the_peaks_in_memory(&peaks_hashes)
     }
 
     pub fn calculate_root_hash(
@@ -545,12 +639,8 @@ impl MMR {
         bag: &str,
         elements_count: usize,
     ) -> Result<String, MMRError> {
-        match self
-            .hasher
+        self.hasher
             .hash(vec![elements_count.to_string(), bag.to_string()])
-        {
-            Ok(root_hash) => Ok(root_hash),
-            Err(e) => Err(MMRError::Hasher(e)),
-        }
+            .map_err(MMRError::Hasher)
     }
 }

--- a/src/mmr/core.rs
+++ b/src/mmr/core.rs
@@ -227,7 +227,12 @@ impl MMR {
         }
 
         // all leaf indices after the passed leaf index
-        let pruned_leaf_indices = (leaf_index + 1)..cur_leaf_count;
+        let pruned_leaf_indices: Vec<usize> = ((leaf_index + 1)..cur_leaf_count)
+            .map(|leaf_index| {
+                let element_index = map_leaf_index_to_element_index(leaf_index);
+                element_index
+            })
+            .collect();
 
         // now collect the leaf hashes for each of these
         let pruned_leaf_hashes = self

--- a/src/mmr/core.rs
+++ b/src/mmr/core.rs
@@ -16,7 +16,9 @@ use crate::mmr::{
     },
 };
 
-use super::{FormattingError, PeaksOptions, TreeMetadataKeysError};
+use super::{
+    map_leaf_index_to_element_index, FormattingError, PeaksOptions, TreeMetadataKeysError,
+};
 
 /// An error that can occur when using an MMR
 #[derive(Error, Debug)]
@@ -39,6 +41,8 @@ pub enum MMRError {
     TreeMetadataKeys(#[from] TreeMetadataKeysError),
     #[error("Formatting error: {0}")]
     Formatting(#[from] FormattingError),
+    #[error("Invalid rewind target")]
+    InvalidRewindTarget,
     #[error("No hash found for index {0}")]
     NoHashFoundForIndex(usize),
 }
@@ -214,6 +218,43 @@ impl MMR {
             element_index: leaf_element_index,
             root_hash,
         })
+    }
+
+    pub async fn rewind(&mut self, leaf_index: usize) -> Result<(), MMRError> {
+        if leaf_index > self.leaves_count.get().await? {
+            return Err(MMRError::InvalidElementIndex);
+        }
+
+        let pre_rewind_elements_count = self.elements_count.get().await?;
+
+        let element_index = map_leaf_index_to_element_index(leaf_index);
+
+        let post_rewind_elements_count = element_index;
+        let post_rewind_leaves_count = leaf_index + 1;
+
+        println!("prewind");
+
+        println!("leaves count set");
+        self.elements_count.set(post_rewind_elements_count).await?;
+        println!("elements count set");
+        // truncate hashes past the element index of the passed leaf
+        self.hashes
+            .delete_range(post_rewind_elements_count + 1, pre_rewind_elements_count)
+            .await?;
+        println!("hashes truncated");
+
+        // recalculate the root hash
+        let bag = self.bag_the_peaks(Some(post_rewind_elements_count)).await?;
+        println!("bag the peaks");
+        let root_hash = self.calculate_root_hash(&bag, post_rewind_elements_count)?;
+        println!("root hash calculated");
+        self.root_hash.set(&root_hash, SubKey::None).await?;
+        println!("root hash set");
+
+        // update counters to historical leaf passed
+        self.leaves_count.set(post_rewind_leaves_count).await?;
+
+        Ok(())
     }
 
     pub async fn get_proof(

--- a/src/mmr/core.rs
+++ b/src/mmr/core.rs
@@ -220,7 +220,7 @@ impl MMR {
         })
     }
 
-    pub async fn rewind(&mut self, leaf_index: usize) -> Result<Vec<usize>, MMRError> {
+    pub async fn rewind(&mut self, leaf_index: usize) -> Result<Vec<String>, MMRError> {
         let cur_leaf_count = self.leaves_count.get().await?;
         if leaf_index > cur_leaf_count {
             return Err(MMRError::InvalidElementIndex);
@@ -228,6 +228,12 @@ impl MMR {
 
         // all leaf indices after the passed leaf index
         let pruned_leaf_indices = (leaf_index + 1)..cur_leaf_count;
+
+        // now collect the leaf hashes for each of these
+        let pruned_leaf_hashes = self
+            .hashes
+            .get_many(pruned_leaf_indices.into_iter().map(SubKey::Usize).collect())
+            .await?;
 
         let pre_rewind_elements_count = self.elements_count.get().await?;
 
@@ -249,7 +255,7 @@ impl MMR {
 
         self.leaves_count.set(post_rewind_leaves_count).await?;
 
-        Ok(pruned_leaf_indices.collect())
+        Ok(pruned_leaf_hashes.values().cloned().collect())
     }
 
     pub async fn get_proof(

--- a/src/mmr/core.rs
+++ b/src/mmr/core.rs
@@ -220,10 +220,14 @@ impl MMR {
         })
     }
 
-    pub async fn rewind(&mut self, leaf_index: usize) -> Result<(), MMRError> {
-        if leaf_index > self.leaves_count.get().await? {
+    pub async fn rewind(&mut self, leaf_index: usize) -> Result<Vec<usize>, MMRError> {
+        let cur_leaf_count = self.leaves_count.get().await?;
+        if leaf_index > cur_leaf_count {
             return Err(MMRError::InvalidElementIndex);
         }
+
+        // all leaf indices after the passed leaf index
+        let pruned_leaf_indices = (leaf_index + 1)..cur_leaf_count;
 
         let pre_rewind_elements_count = self.elements_count.get().await?;
 
@@ -232,29 +236,20 @@ impl MMR {
         let post_rewind_elements_count = element_index;
         let post_rewind_leaves_count = leaf_index + 1;
 
-        println!("prewind");
-
-        println!("leaves count set");
         self.elements_count.set(post_rewind_elements_count).await?;
-        println!("elements count set");
         // truncate hashes past the element index of the passed leaf
         self.hashes
             .delete_range(post_rewind_elements_count + 1, pre_rewind_elements_count)
             .await?;
-        println!("hashes truncated");
 
         // recalculate the root hash
         let bag = self.bag_the_peaks(Some(post_rewind_elements_count)).await?;
-        println!("bag the peaks");
         let root_hash = self.calculate_root_hash(&bag, post_rewind_elements_count)?;
-        println!("root hash calculated");
         self.root_hash.set(&root_hash, SubKey::None).await?;
-        println!("root hash set");
 
-        // update counters to historical leaf passed
         self.leaves_count.set(post_rewind_leaves_count).await?;
 
-        Ok(())
+        Ok(pruned_leaf_indices.collect())
     }
 
     pub async fn get_proof(

--- a/src/store/stores/sqlite.rs
+++ b/src/store/stores/sqlite.rs
@@ -31,13 +31,17 @@ impl SQLiteStore {
         create_file_if_not_exists: Option<bool>,
         id: Option<&str>,
     ) -> Result<Self, Error> {
+        // 8GB RAM, 4 modern cores, SSD storage
         let options = SqliteConnectOptions::from_str(path)?
             .create_if_missing(create_file_if_not_exists.unwrap_or(false))
             .pragma("synchronous", "NORMAL")
             .pragma("journal_mode", "WAL")
+            // 16MB
             .pragma("cache_size", "-16000")
             .pragma("temp_store", "MEMORY")
-            .pragma("mmap_size", "30000000000")
+            // 2GB
+            .pragma("mmap_size", "2147483648")
+            // 4KB
             .pragma("page_size", "4096")
             .busy_timeout(Duration::from_secs(30));
 

--- a/src/store/stores/sqlite.rs
+++ b/src/store/stores/sqlite.rs
@@ -1,7 +1,12 @@
 use async_trait::async_trait;
 use sqlx::Error;
-use sqlx::{sqlite::SqliteConnectOptions, Pool, Row, Sqlite, SqlitePool};
+use sqlx::{
+    sqlite::{SqliteConnectOptions, SqlitePoolOptions},
+    Pool, Row, Sqlite, SqlitePool,
+};
 use std::collections::HashMap;
+use std::str::FromStr;
+use std::time::Duration;
 use tokio::sync::Mutex;
 
 use crate::store::StoreError;
@@ -25,14 +30,18 @@ impl SQLiteStore {
         create_file_if_not_exists: Option<bool>,
         id: Option<&str>,
     ) -> Result<Self, Error> {
-        let pool = if let Some(create_file_if_not_exists) = create_file_if_not_exists {
-            let options = SqliteConnectOptions::new()
-                .filename(path)
-                .create_if_missing(create_file_if_not_exists);
-            SqlitePool::connect_with(options).await?
-        } else {
-            SqlitePool::connect(path).await?
-        };
+        let options = SqliteConnectOptions::from_str(path)?
+            .create_if_missing(create_file_if_not_exists.unwrap_or(false))
+            .pragma("synchronous", "NORMAL")
+            .pragma("journal_mode", "WAL")
+            .pragma("cache_size", "-8000")
+            .pragma("temp_store", "MEMORY")
+            .busy_timeout(Duration::from_secs(30));
+
+        let pool = SqlitePoolOptions::new()
+            .max_connections(10)
+            .connect_with(options)
+            .await?;
 
         let store = SQLiteStore {
             id: id.map(|v| v.to_string()),
@@ -44,6 +53,7 @@ impl SQLiteStore {
 
     async fn init(&self) -> Result<(), Error> {
         let pool = self.db.lock().await;
+        
         sqlx::query(
             r#"CREATE TABLE IF NOT EXISTS store (
                 key TEXT PRIMARY KEY,
@@ -52,6 +62,11 @@ impl SQLiteStore {
         )
         .execute(&*pool)
         .await?;
+        
+        sqlx::query("CREATE INDEX IF NOT EXISTS idx_store_key ON store (key);")
+            .execute(&*pool)
+            .await?;
+        
         Ok(())
     }
 }
@@ -79,8 +94,12 @@ impl Store for SQLiteStore {
     }
 
     async fn get_many(&self, keys: Vec<&str>) -> Result<HashMap<String, String>, StoreError> {
+        if keys.is_empty() {
+            return Ok(HashMap::new());
+        }
+        
         let pool = self.db.lock().await;
-        let mut map = HashMap::new();
+        let mut map = HashMap::with_capacity(keys.len());
 
         for key_chunk in keys.chunks(MAX_VARIABLE_NUMBER) {
             let placeholders = key_chunk.iter().map(|_| "?").collect::<Vec<_>>().join(", ");
@@ -118,13 +137,17 @@ impl Store for SQLiteStore {
     }
 
     async fn set_many(&self, entries: HashMap<String, String>) -> Result<(), StoreError> {
+        if entries.is_empty() {
+            return Ok(());
+        }
+        
         let pool = self.db.lock().await;
         let mut transaction = pool.begin().await?;
 
         for entry_chunk in entries
             .iter()
             .collect::<Vec<_>>()
-            .chunks(MAX_VARIABLE_NUMBER)
+            .chunks(MAX_VARIABLE_NUMBER / 2)
         {
             let mut query = String::from("INSERT OR REPLACE INTO store (key, value) VALUES ");
             let placeholders = entry_chunk
@@ -157,7 +180,12 @@ impl Store for SQLiteStore {
     }
 
     async fn delete_many(&self, keys: Vec<&str>) -> Result<(), StoreError> {
+        if keys.is_empty() {
+            return Ok(());
+        }
+        
         let pool = self.db.lock().await;
+        let mut transaction = pool.begin().await?;
 
         for key_chunk in keys.chunks(MAX_VARIABLE_NUMBER) {
             let placeholders = key_chunk.iter().map(|_| "?").collect::<Vec<_>>().join(", ");
@@ -169,9 +197,10 @@ impl Store for SQLiteStore {
                 query = query.bind(*key);
             }
 
-            query.execute(&*pool).await?;
+            query.execute(&mut *transaction).await?;
         }
 
+        transaction.commit().await?;
         Ok(())
     }
 }

--- a/src/store/stores/sqlite.rs
+++ b/src/store/stores/sqlite.rs
@@ -22,7 +22,8 @@ pub struct SQLiteStore {
 
 //? SQLite's default maximum number of variables per statement is 999.
 //? We use a smaller number to be safe.
-const MAX_VARIABLE_NUMBER: usize = 900;
+// CHANGE BACK TO 900!!!! just for testing
+const MAX_VARIABLE_NUMBER: usize = 990;
 
 impl SQLiteStore {
     pub async fn new(
@@ -34,12 +35,14 @@ impl SQLiteStore {
             .create_if_missing(create_file_if_not_exists.unwrap_or(false))
             .pragma("synchronous", "NORMAL")
             .pragma("journal_mode", "WAL")
-            .pragma("cache_size", "-8000")
+            .pragma("cache_size", "-16000")
             .pragma("temp_store", "MEMORY")
+            .pragma("mmap_size", "30000000000")
+            .pragma("page_size", "4096")
             .busy_timeout(Duration::from_secs(30));
 
         let pool = SqlitePoolOptions::new()
-            .max_connections(10)
+            .max_connections(20)
             .connect_with(options)
             .await?;
 
@@ -53,7 +56,7 @@ impl SQLiteStore {
 
     async fn init(&self) -> Result<(), Error> {
         let pool = self.db.lock().await;
-        
+                
         sqlx::query(
             r#"CREATE TABLE IF NOT EXISTS store (
                 key TEXT PRIMARY KEY,

--- a/src/store/table.rs
+++ b/src/store/table.rs
@@ -158,6 +158,17 @@ impl InStoreTable {
         Ok(store.get(&full_key).await.unwrap_or_default())
     }
 
+    /// Efficiently clear the underlying store of all usize keys in a range
+    pub async fn delete_range(&self, start: usize, end: usize) -> Result<(), InStoreTableError> {
+        let deleted_keys: Vec<String> = (start..end)
+            .map(|i| InStoreTable::get_full_key(&self.key, &i.to_string()))
+            .collect();
+        self.store
+            .delete_many(deleted_keys.iter().map(|s| s.as_str()).collect())
+            .await?;
+        Ok(())
+    }
+
     /// Get the values from full keys that retrieved from the sub_keys
     pub async fn get_many(
         &self,

--- a/tests/mmr/core.rs
+++ b/tests/mmr/core.rs
@@ -87,12 +87,12 @@ async fn test_rewind_scenario() {
     );
 
     // 5) Rewind back to when there were n=5 leaves
-    let pruned_leaf_indices = mmr
+    let pruned_leaf_hashes = mmr
         .rewind(leaf_index)
         .await
         .expect("Failed to rewind to original size");
 
-    assert_eq!(pruned_leaf_indices.len(), new_leaf_count);
+    assert_eq!(pruned_leaf_hashes.len(), new_leaf_count);
 
     println!("rewind complete");
     println!(
@@ -989,4 +989,56 @@ async fn timestamp_remappers_test() {
 
     let correct_root_hash = "0x32f5a2949cac3d06e854701c5a2a00ed51c0475a31c1bc17cc6d3ec46425e9";
     assert_eq!(correct_root_hash, root_hash);
+}
+
+#[tokio::test]
+async fn test_rewind_pruned_leaves() {
+    use std::collections::HashSet;
+
+    // 1) Set up an MMR with 5 initial leaves (["1", "2", "3", "4", "5"])
+    let (mut mmr, appended_results) = setup().await.0;
+    assert_eq!(appended_results.len(), 5);
+
+    // 2) Append 3 new leaves
+    let new_leaves = ["x0", "x1", "x2"];
+    for leaf in &new_leaves {
+        mmr.append((*leaf).to_string())
+            .await
+            .expect("Failed to append new leaf");
+    }
+
+    // The leaf index for the 5th leaf is 4 (since indexing starts at 0),
+    // so rewinding to 4 effectively prunes leaves #5, #6, and #7
+    let rewind_target = 4;
+
+    // 3) Call rewind(...) and capture which leaves get pruned
+    let pruned_leaf_hashes = mmr
+        .rewind(rewind_target)
+        .await
+        .expect("Failed to rewind MMR");
+
+    // 4) Validate that the returned leaves are exactly our 3 newly appended leaves
+    //    Because the store returns them in a HashMap, there’s no guaranteed order;
+    //    we compare sets to avoid ordering confusion.
+    let expected_set: HashSet<String> = new_leaves.iter().map(|s| s.to_string()).collect();
+    let actual_set: HashSet<String> = pruned_leaf_hashes.into_iter().collect();
+    assert_eq!(
+        expected_set, actual_set,
+        "The pruned leaves should match the newly appended leaves"
+    );
+
+    // 5) Finally, confirm that the MMR is back to having only the original 5 leaves
+    let leaves_count_after = mmr.leaves_count.get().await.unwrap();
+    assert_eq!(leaves_count_after, 5, "We should have 5 leaves now");
+
+    // Optionally, confirm the last leaf's proof is still valid, etc.:
+    let last_leaf_idx = appended_results.last().unwrap().element_index; // index for "5"
+    let proof = mmr.get_proof(last_leaf_idx, None).await.unwrap();
+    let last_leaf_value = LEAVES[LEAVES.len() - 1]; // "5"
+    assert!(
+        mmr.verify_proof(proof, last_leaf_value.to_string(), None)
+            .await
+            .expect("Failed to verify proof"),
+        "The proof for the 5th leaf should remain valid after rewind"
+    );
 }

--- a/tests/mmr/core.rs
+++ b/tests/mmr/core.rs
@@ -5,7 +5,7 @@ use accumulators::{
         keccak::KeccakHasher, stark_pedersen::StarkPedersenHasher,
         stark_poseidon::StarkPoseidonHasher, Hasher,
     },
-    mmr::{AppendResult, PeaksOptions, Proof, ProofOptions, MMR},
+    mmr::{map_leaf_index_to_element_index, AppendResult, PeaksOptions, Proof, ProofOptions, MMR},
     store::{memory::InMemoryStore, sqlite::SQLiteStore, SubKey},
 };
 
@@ -40,6 +40,180 @@ async fn setup() -> (
         (keccak_mmr, append_result_keccak),
         (pedersen_mmr, append_result_pedersen),
     )
+}
+//================================================================================================
+// Tests for rewind
+//================================================================================================
+
+#[tokio::test]
+async fn test_rewind_scenario() {
+    // 1) Set up an MMR with 5 initial leaves (the default in `LEAVES`)
+    let (mut mmr, appended_results) = setup().await.0;
+    // n = 5 leaves
+    let n = appended_results.len();
+    let leaf_index = n - 1;
+
+    // 2) Grab the element index + value for the last leaf
+    let last_leaf_result = appended_results.last().unwrap();
+    let last_leaf_index = last_leaf_result.element_index;
+    // The leaf value is "5" from the global `LEAVES` array
+    let last_leaf_value = LEAVES[LEAVES.len() - 1];
+
+    // 3) Get a proof for the last leaf
+    let original_proof = mmr
+        .get_proof(last_leaf_index, None)
+        .await
+        .expect("Failed to get proof for last leaf");
+
+    println!(
+        "pre addition elements & leaves count: {} {}",
+        mmr.elements_count.get().await.unwrap(),
+        mmr.leaves_count.get().await.unwrap()
+    );
+
+    // 4) Append b=3 new leaves
+    for i in 0..3 {
+        mmr.append(format!("new_leaf_{}", i))
+            .await
+            .expect("Failed to append new leaf");
+    }
+
+    println!(
+        "post addition elements & leaves count: {} {}",
+        mmr.elements_count.get().await.unwrap(),
+        mmr.leaves_count.get().await.unwrap()
+    );
+
+    // 5) Rewind back to when there were n=5 leaves
+    mmr.rewind(leaf_index)
+        .await
+        .expect("Failed to rewind to original size");
+
+    println!("rewind complete");
+    println!(
+        "post rewind elements & leaves count: {} {}",
+        mmr.elements_count.get().await.unwrap(),
+        mmr.leaves_count.get().await.unwrap()
+    );
+
+    // 6) Get that same proof again (for the same leaf index)
+    let rewound_proof = mmr
+        .get_proof(last_leaf_index, None)
+        .await
+        .expect("Failed to get proof after rewinding");
+
+    // 7) Confirm the proof *before* and *after* rewinding are the same
+    assert_eq!(original_proof, rewound_proof);
+
+    // 8) Verify the rewound proof is still valid
+    assert!(mmr
+        .verify_proof(rewound_proof, last_leaf_value.to_string(), None)
+        .await
+        .expect("Failed to verify rewound proof"));
+}
+
+#[tokio::test]
+async fn test_rewind_mid_leaf() {
+    // 1) Set up an MMR with 5 initial leaves
+    let (mut mmr, appended_results) = setup().await.0; // Poseidon again
+                                                       // n = 5
+    let n = appended_results.len();
+
+    // 2) Pick a *middle* leaf, e.g. the 3rd leaf
+    //    appended_results are in insertion order, so index=2 is the 3rd leaf.
+    let mid_leaf_result = &appended_results[2];
+    let mid_leaf_index = mid_leaf_result.element_index;
+    let mid_leaf_value = LEAVES[2]; // "3"
+
+    // 3) Get a proof for that middle leaf
+    let original_proof = mmr
+        .get_proof(mid_leaf_index, None)
+        .await
+        .expect("Failed to get proof for mid leaf");
+
+    // 4) Append b=3 new leaves
+    for i in 0..3 {
+        mmr.append(format!("middle_rewind_leaf_{}", i))
+            .await
+            .expect("Failed to append new leaf");
+    }
+
+    // 5) Rewind back to n=5
+    mmr.rewind(n - 1)
+        .await
+        .expect("Failed to rewind to original size");
+
+    // 6) Get the same leaf's proof again
+    let rewound_proof = mmr
+        .get_proof(mid_leaf_index, None)
+        .await
+        .expect("Failed to get proof after rewinding");
+
+    // 7) Confirm they match
+    assert_eq!(original_proof, rewound_proof);
+
+    // 8) Verify that proof is still valid
+    assert!(mmr
+        .verify_proof(rewound_proof, mid_leaf_value.to_string(), None)
+        .await
+        .expect("Failed to verify rewound proof for mid leaf"));
+}
+
+#[tokio::test]
+async fn test_simulated_proof_generation() {
+    // this test should setup an MMR with n leaves, then create a proof for the nth leaf, then add `b` new leaves, then call the get_proof function with the nth leaf's element index and with the element count as `n` as it was originally generated, then verify these proofs are the same and valid
+    let (mmr, append_result) = setup().await.0;
+    let mut mmr = mmr;
+    let n = append_result.len();
+    let b = 5;
+    let proof = mmr.get_proof(n, None).await.unwrap();
+    mmr.append("6".to_string()).await.unwrap();
+    let proof_post_add = mmr
+        .get_proof(
+            n,
+            Some(ProofOptions {
+                elements_count: Some(map_leaf_index_to_element_index(n - 1)),
+                formatting_opts: None,
+            }),
+        )
+        .await
+        .unwrap();
+    assert_eq!(proof, proof_post_add);
+}
+
+#[tokio::test]
+async fn test_noop_rewind() {
+    // 1) Set up an MMR with 5 initial leaves
+    let (mut mmr, appended_results) = setup().await.0;
+    let n = appended_results.len();
+    let leaf_index = n - 1;
+
+    // Get the current state
+    let original_elements_count = mmr.elements_count.get().await.unwrap();
+    let original_leaves_count = mmr.leaves_count.get().await.unwrap();
+    let original_root = mmr.bag_the_peaks(None).await.unwrap();
+
+    // 2) Rewind to current leaf index (should be a no-op)
+    mmr.rewind(leaf_index)
+        .await
+        .expect("Failed to perform no-op rewind");
+
+    // 3) Verify nothing changed
+    assert_eq!(
+        mmr.elements_count.get().await.unwrap(),
+        original_elements_count,
+        "Elements count should not change after no-op rewind"
+    );
+    assert_eq!(
+        mmr.leaves_count.get().await.unwrap(),
+        original_leaves_count,
+        "Leaves count should not change after no-op rewind"
+    );
+    assert_eq!(
+        mmr.bag_the_peaks(None).await.unwrap(),
+        original_root,
+        "Root hash should not change after no-op rewind"
+    );
 }
 
 //================================================================================================

--- a/tests/mmr/core.rs
+++ b/tests/mmr/core.rs
@@ -1042,3 +1042,356 @@ async fn test_rewind_pruned_leaves() {
         "The proof for the 5th leaf should remain valid after rewind"
     );
 }
+
+#[cfg(test)]
+mod batch_operations_tests {
+    use std::sync::Arc;
+    use std::time::Instant;
+
+    use accumulators::{
+        hasher::{
+            keccak::KeccakHasher, stark_pedersen::StarkPedersenHasher,
+            stark_poseidon::StarkPoseidonHasher,
+        },
+        mmr::MMR,
+        store::{memory::InMemoryStore, sqlite::SQLiteStore, SubKey},
+    };
+
+    async fn setup_mmrs() -> (MMR, MMR, MMR) {
+        let store = Arc::new(InMemoryStore::default());
+        
+        let poseidon_hasher = Arc::new(StarkPoseidonHasher::new(Some(false)));
+        let keccak_hasher = Arc::new(KeccakHasher::new());
+        let pedersen_hasher = Arc::new(StarkPedersenHasher::new());
+        
+        let poseidon_mmr = MMR::new(store.clone(), poseidon_hasher, None);
+        let keccak_mmr = MMR::new(store.clone(), keccak_hasher, None);
+        let pedersen_mmr = MMR::new(store.clone(), pedersen_hasher, None);
+        
+        (poseidon_mmr, keccak_mmr, pedersen_mmr)
+    }
+    
+    #[tokio::test]
+    async fn test_batch_append_basic() {
+        let (mut poseidon_mmr, _, _) = setup_mmrs().await;
+        
+        let leaves = vec![
+            "1".to_string(),
+            "2".to_string(),
+            "3".to_string(),
+            "4".to_string(),
+            "5".to_string()
+        ];
+        
+        let results = poseidon_mmr.batch_append(leaves.clone()).await.unwrap();
+        
+        assert_eq!(results.len(), 5, "Should return 5 result objects");
+        assert_eq!(poseidon_mmr.leaves_count.get().await.unwrap(), 5, "Should have 5 leaves");
+        assert_eq!(results[0].element_index, 1, "First element index should be 1");
+        
+        for i in 1..results.len() {
+            assert!(results[i].element_index > results[i-1].element_index, 
+                "Element indices should be increasing");
+        }
+    }
+    
+    #[tokio::test]
+    async fn test_batch_append_matches_individual_appends() {
+        let (mut batch_mmr, _, _) = setup_mmrs().await;
+        let (mut individual_mmr, _, _) = setup_mmrs().await;
+        
+        let leaves = vec![
+            "1".to_string(),
+            "2".to_string(),
+            "3".to_string(),
+            "4".to_string(),
+            "5".to_string()
+        ];
+        
+        let batch_results = batch_mmr.batch_append(leaves.clone()).await.unwrap();
+        
+        let mut individual_results = Vec::new();
+        for leaf in &leaves {
+            individual_results.push(individual_mmr.append(leaf.clone()).await.unwrap());
+        }
+        
+        assert_eq!(
+            batch_mmr.leaves_count.get().await.unwrap(),
+            individual_mmr.leaves_count.get().await.unwrap(),
+            "Leaf counts should match"
+        );
+        
+        assert_eq!(
+            batch_mmr.elements_count.get().await.unwrap(),
+            individual_mmr.elements_count.get().await.unwrap(),
+            "Element counts should match"
+        );
+        
+        let batch_root = batch_mmr.root_hash.get(SubKey::None).await.unwrap();
+        let individual_root = individual_mmr.root_hash.get(SubKey::None).await.unwrap();
+        assert_eq!(batch_root, individual_root, "Root hashes should match");
+        
+        for (batch_result, individual_result) in batch_results.iter().zip(individual_results.iter()) {
+            assert_eq!(batch_result.element_index, individual_result.element_index, "Element indices should match");
+            assert_eq!(batch_result.leaves_count, individual_result.leaves_count, "Leaf counts should match");
+            assert_eq!(batch_result.elements_count, individual_result.elements_count, "Element counts should match");
+            assert_eq!(batch_result.root_hash, individual_result.root_hash, "Root hashes should match");
+        }
+    }
+    
+    #[tokio::test]
+    async fn test_batch_append_proof_validation() {
+        let (mut mmr, _, _) = setup_mmrs().await;
+        
+        let leaves = vec![
+            "1".to_string(),
+            "2".to_string(),
+            "3".to_string(),
+            "4".to_string(),
+            "5".to_string()
+        ];
+        
+        let results = mmr.batch_append(leaves.clone()).await.unwrap();
+        
+        for (i, result) in results.iter().enumerate() {
+            let proof = mmr.get_proof(result.element_index, None).await.unwrap();
+            let is_valid = mmr.verify_proof(proof, leaves[i].clone(), None).await.unwrap();
+            
+            assert!(is_valid, "Proof for leaf {} should be valid", i);
+        }
+    }
+    
+    #[tokio::test]
+    async fn test_batch_append_empty() {
+        let (mut mmr, _, _) = setup_mmrs().await;
+        
+        let results = mmr.batch_append(Vec::new()).await.unwrap();
+        
+        assert!(results.is_empty(), "Empty batch should return empty results");
+        assert_eq!(mmr.leaves_count.get().await.unwrap(), 0, "Leaf count should remain 0");
+        assert_eq!(mmr.elements_count.get().await.unwrap(), 0, "Element count should remain 0");
+    }
+    
+    #[tokio::test]
+    async fn test_batch_append_single_item() {
+        let (mut batch_mmr, _, _) = setup_mmrs().await;
+        let (mut individual_mmr, _, _) = setup_mmrs().await;
+        
+        let leaf = "single_item".to_string();
+        let batch_results = batch_mmr.batch_append(vec![leaf.clone()]).await.unwrap();
+        let individual_result = individual_mmr.append(leaf.clone()).await.unwrap();
+        
+        assert_eq!(batch_results.len(), 1, "Should have 1 result");
+        assert_eq!(
+            batch_results[0].element_index,
+            individual_result.element_index,
+            "Element indices should match"
+        );
+        assert_eq!(
+            batch_results[0].root_hash,
+            individual_result.root_hash,
+            "Root hashes should match"
+        );
+    }
+    
+    #[tokio::test]
+    async fn test_batch_append_performance() {
+        let (mut batch_mmr, _, _) = setup_mmrs().await;
+        let (mut individual_mmr, _, _) = setup_mmrs().await;
+        
+        let leaf_count = 100;
+        let leaves: Vec<String> = (0..leaf_count)
+            .map(|i| format!("leaf_{}", i))
+            .collect();
+        
+        let batch_start = Instant::now();
+        let _ = batch_mmr.batch_append(leaves.clone()).await.unwrap();
+        let batch_duration = batch_start.elapsed();
+        
+        let individual_start = Instant::now();
+        for leaf in &leaves {
+            let _ = individual_mmr.append(leaf.clone()).await.unwrap();
+        }
+        let individual_duration = individual_start.elapsed();
+        
+        println!("Batch append time: {:?}", batch_duration);
+        println!("Individual append time: {:?}", individual_duration);
+        
+        assert_eq!(batch_mmr.leaves_count.get().await.unwrap(), leaf_count, "Batch MMR should have correct leaf count");
+        assert_eq!(individual_mmr.leaves_count.get().await.unwrap(), leaf_count, "Individual MMR should have correct leaf count");
+    }
+    
+    #[tokio::test]
+    async fn test_batch_append_with_existing_leaves() {
+        let (mut mmr, _, _) = setup_mmrs().await;
+        
+        let initial_leaves = vec!["initial_1".to_string(), "initial_2".to_string()];
+        for leaf in &initial_leaves {
+            mmr.append(leaf.clone()).await.unwrap();
+        }
+        
+        let initial_leaf_count = mmr.leaves_count.get().await.unwrap();
+        assert_eq!(initial_leaf_count, 2, "Should have 2 initial leaves");
+        
+        let batch_leaves = vec!["batch_1".to_string(), "batch_2".to_string(), "batch_3".to_string()];
+        let results = mmr.batch_append(batch_leaves.clone()).await.unwrap();
+        
+        let final_leaf_count = mmr.leaves_count.get().await.unwrap();
+        assert_eq!(final_leaf_count, 5, "Should have 5 total leaves");
+        
+        let initial_proof = mmr.get_proof(1, None).await.unwrap();
+        let is_valid_initial = mmr.verify_proof(initial_proof, initial_leaves[0].clone(), None).await.unwrap();
+        assert!(is_valid_initial, "Proof for initial leaf should be valid");
+        
+        let batch_proof = mmr.get_proof(results[1].element_index, None).await.unwrap();
+        let is_valid_batch = mmr.verify_proof(batch_proof, batch_leaves[1].clone(), None).await.unwrap();
+        assert!(is_valid_batch, "Proof for batch leaf should be valid");
+    }
+    
+    #[tokio::test]
+    async fn test_batch_append_all_hashers() {
+        let (mut poseidon_mmr, mut keccak_mmr, mut pedersen_mmr) = setup_mmrs().await;
+        
+        let leaves = vec![
+            "1".to_string(),
+            "2".to_string(),
+            "3".to_string(),
+            "4".to_string(),
+            "5".to_string()
+        ];
+        
+        let poseidon_results = poseidon_mmr.batch_append(leaves.clone()).await.unwrap();
+        let keccak_results = keccak_mmr.batch_append(leaves.clone()).await.unwrap();
+        let pedersen_results = pedersen_mmr.batch_append(leaves.clone()).await.unwrap();
+        
+        assert_eq!(poseidon_mmr.leaves_count.get().await.unwrap(), 5);
+        assert_eq!(keccak_mmr.leaves_count.get().await.unwrap(), 5);
+        assert_eq!(pedersen_mmr.leaves_count.get().await.unwrap(), 5);
+        
+        let poseidon_root = poseidon_results.last().unwrap().root_hash.clone();
+        let keccak_root = keccak_results.last().unwrap().root_hash.clone();
+        let pedersen_root = pedersen_results.last().unwrap().root_hash.clone();
+        
+        assert_ne!(poseidon_root, keccak_root, "Different hashers should produce different roots");
+        assert_ne!(poseidon_root, pedersen_root, "Different hashers should produce different roots");
+        assert_ne!(keccak_root, pedersen_root, "Different hashers should produce different roots");
+    }
+    
+    #[tokio::test]
+    async fn test_batch_append_with_sqlite() {
+        let store = SQLiteStore::new(":memory:", Some(true), Some("test"))
+            .await
+            .unwrap();
+        let store = Arc::new(store);
+        let hasher = Arc::new(StarkPoseidonHasher::new(Some(false)));
+        
+        let mut mmr = MMR::new(store, hasher, None);
+        
+        let leaves = vec![
+            "1".to_string(),
+            "2".to_string(),
+            "3".to_string(),
+            "4".to_string(),
+            "5".to_string()
+        ];
+        
+        let results = mmr.batch_append(leaves.clone()).await.unwrap();
+        
+        assert_eq!(mmr.leaves_count.get().await.unwrap(), 5, "Should have 5 leaves");
+        
+        for (i, result) in results.iter().enumerate() {
+            let proof = mmr.get_proof(result.element_index, None).await.unwrap();
+            let is_valid = mmr.verify_proof(proof, leaves[i].clone(), None).await.unwrap();
+            
+            assert!(is_valid, "Proof for leaf {} should be valid with SQLite store", i);
+        }
+    }
+    
+    #[tokio::test]
+    async fn test_bag_the_peaks_in_memory() {
+        let (mmr, _, _) = setup_mmrs().await;
+        
+        // let leaves = vec![
+        //     "1".to_string(),
+        //     "2".to_string(),
+        //     "3".to_string(),
+        //     "4".to_string(),
+        //     "5".to_string()
+        // ];
+        
+        // let results = mmr.batch_append(leaves.clone()).await.unwrap();
+        
+        let peaks_from_storage = mmr.get_peaks(accumulators::mmr::PeaksOptions {
+            elements_count: None,
+            formatting_opts: None,
+        }).await.unwrap();
+        
+        let bagged_peaks_from_storage = mmr.bag_the_peaks(None).await.unwrap();
+        let bagged_peaks_in_memory = mmr.bag_the_peaks_in_memory(&peaks_from_storage).unwrap();
+        
+        assert_eq!(
+            bagged_peaks_from_storage, 
+            bagged_peaks_in_memory,
+            "In-memory and storage-based peak bagging should match"
+        );
+    }
+    
+    #[tokio::test]
+    async fn test_rewind_after_batch_append() {
+        let (mut mmr, _, _) = setup_mmrs().await;
+        
+        let first_batch = vec![
+            "1".to_string(),
+            "2".to_string(),
+            "3".to_string(),
+        ];
+        
+        mmr.batch_append(first_batch.clone()).await.unwrap();
+        
+        let root_after_first = mmr.root_hash.get(SubKey::None).await.unwrap().unwrap();
+        
+        let second_batch = vec![
+            "4".to_string(),
+            "5".to_string(),
+        ];
+        
+        mmr.batch_append(second_batch.clone()).await.unwrap();
+        
+        assert_eq!(mmr.leaves_count.get().await.unwrap(), 5, "Should have 5 leaves before rewind");
+        
+        let pruned = mmr.rewind(2).await.unwrap();
+        
+        assert_eq!(pruned.len(), 2, "Should have pruned 2 leaves");
+        assert!(pruned.contains(&second_batch[0]), "Should contain first leaf from second batch");
+        assert!(pruned.contains(&second_batch[1]), "Should contain second leaf from second batch");
+        assert_eq!(mmr.leaves_count.get().await.unwrap(), 3, "Should have 3 leaves after rewind");
+        
+        let root_after_rewind = mmr.root_hash.get(SubKey::None).await.unwrap().unwrap();
+        assert_eq!(root_after_first, root_after_rewind, "Root should match state after first batch");
+    }
+    
+    #[tokio::test]
+    async fn test_large_batch_append() {
+        let (mut mmr, _, _) = setup_mmrs().await;
+        
+        const BATCH_SIZE: usize = 1000;
+        let large_batch: Vec<String> = (0..BATCH_SIZE)
+            .map(|i| format!("large_batch_item_{}", i))
+            .collect();
+        
+        let results = mmr.batch_append(large_batch.clone()).await.unwrap();
+        
+        assert_eq!(results.len(), BATCH_SIZE, "Should have results for all items");
+        assert_eq!(mmr.leaves_count.get().await.unwrap(), BATCH_SIZE, "Should have correct leaf count");
+        
+        let indices_to_check = [0, BATCH_SIZE / 2, BATCH_SIZE - 1];
+        
+        for &idx in &indices_to_check {
+            let element_idx = results[idx].element_index;
+            let proof = mmr.get_proof(element_idx, None).await.unwrap();
+            let is_valid = mmr.verify_proof(proof, large_batch[idx].clone(), None).await.unwrap();
+            
+            assert!(is_valid, "Proof for item {} should be valid", idx);
+        }
+    }
+}

--- a/tests/mmr/core.rs
+++ b/tests/mmr/core.rs
@@ -71,8 +71,10 @@ async fn test_rewind_scenario() {
         mmr.leaves_count.get().await.unwrap()
     );
 
+    let new_leaf_count = 3;
+
     // 4) Append b=3 new leaves
-    for i in 0..3 {
+    for i in 0..new_leaf_count {
         mmr.append(format!("new_leaf_{}", i))
             .await
             .expect("Failed to append new leaf");
@@ -85,9 +87,12 @@ async fn test_rewind_scenario() {
     );
 
     // 5) Rewind back to when there were n=5 leaves
-    mmr.rewind(leaf_index)
+    let pruned_leaf_indices = mmr
+        .rewind(leaf_index)
         .await
         .expect("Failed to rewind to original size");
+
+    assert_eq!(pruned_leaf_indices.len(), new_leaf_count);
 
     println!("rewind complete");
     println!(


### PR DESCRIPTION
For SQLite added pragma settings, limited max concurrent operations, busy timeout, indexed the key column, grouped multiple operations into a single atomic unit. For MMR created batch_append to process multiple leaves simultaneously.