### PR TITLE
Sqlite store: create with pool, use acquire instead of mutex

### DIFF
--- a/src/store/core.rs
+++ b/src/store/core.rs
@@ -5,10 +5,7 @@ use thiserror::Error;
 /// An error that can occur when using a store
 #[derive(Error, Debug)]
 pub enum StoreError {
-    #[error(
-        "
-   Fail to get value from store"
-    )]
+    #[error("Fail to get value from store")]
     GetError,
     #[error("Fail to set value in store")]
     SetError,
@@ -24,6 +21,8 @@ pub enum StoreError {
     SQLite(#[from] sqlx::Error),
     #[error("Parse error: {0}")]
     Parse(#[from] ParseIntError),
+    #[error("Custom error: {0:?}")]
+    Custom(Box<dyn std::error::Error + Send + Sync + 'static>),
 }
 
 /// Define common behavior for all stores

--- a/src/store/stores/sqlite.rs
+++ b/src/store/stores/sqlite.rs
@@ -1,8 +1,10 @@
 use async_trait::async_trait;
-use sqlx::Error;
+use sqlx::pool::PoolConnection;
+use sqlx::SqliteConnection;
 use sqlx::{sqlite::SqliteConnectOptions, Pool, Row, Sqlite, SqlitePool};
+use sqlx::{Acquire, Error};
 use std::collections::HashMap;
-use tokio::sync::Mutex;
+use std::ops::DerefMut;
 
 use crate::store::StoreError;
 
@@ -12,7 +14,8 @@ use super::super::Store;
 #[derive(Debug)]
 pub struct SQLiteStore {
     pub id: Option<String>,
-    db: Mutex<Pool<Sqlite>>,
+    pool: Pool<Sqlite>,
+    atomic_set_many: bool,
 }
 
 //? SQLite's default maximum number of variables per statement is 999.
@@ -20,6 +23,15 @@ pub struct SQLiteStore {
 const MAX_VARIABLE_NUMBER: usize = 900;
 
 impl SQLiteStore {
+    /// Create a new SQLite store with externally created pool.
+    pub fn with_pool(pool: Pool<Sqlite>, id: Option<String>) -> Self {
+        SQLiteStore {
+            id,
+            pool,
+            atomic_set_many: false,
+        }
+    }
+
     pub async fn new(
         path: &str,
         create_file_if_not_exists: Option<bool>,
@@ -36,21 +48,30 @@ impl SQLiteStore {
 
         let store = SQLiteStore {
             id: id.map(|v| v.to_string()),
-            db: Mutex::new(pool),
+            pool,
+            atomic_set_many: true,
         };
         store.init().await?;
         Ok(store)
     }
 
-    async fn init(&self) -> Result<(), Error> {
-        let pool = self.db.lock().await;
+    /// Acquire a connection from the pool.
+    /// NOTE: if there's no available connection this function will fail after acquire timeout.
+    /// Configure it via sqlite options.
+    pub async fn acquire_connection(&self) -> Result<PoolConnection<Sqlite>, Error> {
+        self.pool.acquire().await
+    }
+
+    /// Initialize the store
+    pub async fn init(&self) -> Result<(), Error> {
+        let mut conn = self.acquire_connection().await?;
         sqlx::query(
             r#"CREATE TABLE IF NOT EXISTS store (
                 key TEXT PRIMARY KEY,
                 value TEXT NOT NULL
             );"#,
         )
-        .execute(&*pool)
+        .execute(conn.deref_mut())
         .await?;
         Ok(())
     }
@@ -63,11 +84,11 @@ impl Store for SQLiteStore {
     }
 
     async fn get(&self, key: &str) -> Result<Option<String>, StoreError> {
-        let pool = self.db.lock().await;
+        let mut conn = self.acquire_connection().await?;
 
         let row = sqlx::query("SELECT value FROM store WHERE key = ?")
             .bind(key)
-            .fetch_optional(&*pool)
+            .fetch_optional(conn.deref_mut())
             .await?;
 
         if let Some(row) = row {
@@ -79,7 +100,7 @@ impl Store for SQLiteStore {
     }
 
     async fn get_many(&self, keys: Vec<&str>) -> Result<HashMap<String, String>, StoreError> {
-        let pool = self.db.lock().await;
+        let mut conn = self.acquire_connection().await?;
         let mut map = HashMap::new();
 
         for key_chunk in keys.chunks(MAX_VARIABLE_NUMBER) {
@@ -93,7 +114,7 @@ impl Store for SQLiteStore {
                 query = query.bind(*key);
             }
 
-            let rows = query.fetch_all(&*pool).await?;
+            let rows = query.fetch_all(conn.deref_mut()).await?;
             for row in rows {
                 let key: String = row.get("key");
                 let value: String = row.get("value");
@@ -105,57 +126,40 @@ impl Store for SQLiteStore {
     }
 
     async fn set(&self, key: &str, value: &str) -> Result<(), StoreError> {
-        let pool = self.db.lock().await;
+        let mut conn = self.acquire_connection().await?;
         sqlx::query("INSERT OR REPLACE INTO store (key, value) VALUES (?, ?)")
             .bind(key)
             .bind(value)
-            .execute(&*pool)
+            .execute(conn.deref_mut())
             .await?;
 
         Ok(())
     }
 
     async fn set_many(&self, entries: HashMap<String, String>) -> Result<(), StoreError> {
-        let pool = self.db.lock().await;
-        let mut transaction = pool.begin().await?;
-
-        for entry_chunk in entries
-            .iter()
-            .collect::<Vec<_>>()
-            .chunks(MAX_VARIABLE_NUMBER)
-        {
-            let mut query = String::from("INSERT OR REPLACE INTO store (key, value) VALUES ");
-            let placeholders = entry_chunk
-                .iter()
-                .map(|_| "(?, ?)")
-                .collect::<Vec<_>>()
-                .join(", ");
-            query.push_str(&placeholders);
-
-            let mut sqlx_query = sqlx::query(&query);
-            for (key, value) in entry_chunk {
-                sqlx_query = sqlx_query.bind(key).bind(value);
+        let mut conn = self.acquire_connection().await?;
+        match self.atomic_set_many {
+            true => {
+                let mut tx = conn.begin().await?;
+                set_many(tx.deref_mut(), entries).await?;
+                tx.commit().await.map_err(StoreError::SQLite)
             }
-
-            sqlx_query.execute(&mut *transaction).await?;
+            false => set_many(conn.deref_mut(), entries).await,
         }
-
-        transaction.commit().await?;
-        Ok(())
     }
 
     async fn delete(&self, key: &str) -> Result<(), StoreError> {
-        let pool = self.db.lock().await;
+        let mut conn = self.acquire_connection().await?;
         sqlx::query("DELETE FROM store WHERE key = ?")
             .bind(key)
-            .execute(&*pool)
+            .execute(conn.deref_mut())
             .await?;
 
         Ok(())
     }
 
     async fn delete_many(&self, keys: Vec<&str>) -> Result<(), StoreError> {
-        let pool = self.db.lock().await;
+        let mut conn = self.acquire_connection().await?;
 
         for key_chunk in keys.chunks(MAX_VARIABLE_NUMBER) {
             let placeholders = key_chunk.iter().map(|_| "?").collect::<Vec<_>>().join(", ");
@@ -167,9 +171,36 @@ impl Store for SQLiteStore {
                 query = query.bind(*key);
             }
 
-            query.execute(&*pool).await?;
+            query.execute(conn.deref_mut()).await?;
         }
 
         Ok(())
     }
+}
+
+async fn set_many(
+    executor: &mut SqliteConnection,
+    entries: HashMap<String, String>,
+) -> Result<(), StoreError> {
+    for entry_chunk in entries
+        .iter()
+        .collect::<Vec<_>>()
+        .chunks(MAX_VARIABLE_NUMBER)
+    {
+        let mut query = String::from("INSERT OR REPLACE INTO store (key, value) VALUES ");
+        let placeholders = entry_chunk
+            .iter()
+            .map(|_| "(?, ?)")
+            .collect::<Vec<_>>()
+            .join(", ");
+        query.push_str(&placeholders);
+
+        let mut sqlx_query = sqlx::query(&query);
+        for (key, value) in entry_chunk {
+            sqlx_query = sqlx_query.bind(key).bind(value);
+        }
+
+        sqlx_query.execute(&mut *executor).await?;
+    }
+    Ok(())
 }


### PR DESCRIPTION
Pool has its own thread-safety mechanism implemented, which we can reuse.  
It's particularly useful when creating multiple concurrent read-only connections (now possible with the new `with_pool` constructor).
Note the `atomic_set_many` — this is a backward compatibility flag to ensure the same behaviour.  